### PR TITLE
Merge pull request #31 from sw-yx/v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ yarn add react-netlify-identity
 - `authedFetch(endpoint: string, obj: RequestInit = {})` a thin axios-like wrapper over `fetch` that has the user's JWT attached, for convenience pinging Netlify Functions with Netlify Identity
 - `param: TokenParam`
   - a token exposing Netlify tokens a dev has to implement the actions for; namely `invite`, `recovery`, `email_change` and `access_denied`
-  - for further reference, please check the [type definition](https://github.com/sw-yx/react-netlify-identity/tree/master/src/token.ts)
-  - implementation for a Recovery Example below
   - **Important:** tokens this package exposes no methods for are automatically handled and will not be passed down - see [runRoutes implementation](https://github.com/sw-yx/react-netlify-identity/master/src/runRoutes.tsx)
   - if you don't want this behaviour (added [here](https://github.com/sw-yx/react-netlify-identity/issues/12) in v.0.1.8), pass `runRoutes={false}` to the exposed hook
-- `recoverAccount(remember?: boolean)`:
+  - for further reference, please check the [type definition](https://github.com/sw-yx/react-netlify-identity/tree/master/src/token.ts)
+  - an example implementation for a Recovery process can be found below
+- `recoverAccount(remember?: boolean)`: verifies and consumes the recovery token caught by `runRoutes`, sets user on success
 
 ```tsx
 import React from 'react';
@@ -258,14 +258,14 @@ function CatchNetlifyRecoveryNullComponent() {
   return null;
 }
 
-function RecoveyPage() {
+function RecoveryPage() {
   const {
     location: { state },
   } = useHistory();
   // this state _might_ not be needed, it was needed in my specific implementation
   const [token] = useState(state?.token);
 
-  return null; // do something with the token
+  return null; // set new password in a form and call updateUser
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-netlify-identity",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "use netlify identity with react",
   "author": "sw-yx",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -221,11 +221,15 @@ export function useNetlifyIdentity(
         throw new Error(errors.tokenMissingOrInvalid);
       }
 
-      return goTrueInstance.recover(param.token, remember).then(user => {
-        // clean up consumed token
-        setParam(defaultParam);
-        return _setUser(user);
-      });
+      return goTrueInstance
+        .recover(param.token, remember)
+        .then(user => {
+          return _setUser(user);
+        })
+        .finally(() => {
+          // clean up consumed token
+          setParam(defaultParam);
+        });
     },
     [goTrueInstance, _setUser, param]
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -218,7 +218,7 @@ export function useNetlifyIdentity(
   );
 
   const recoverAccount = useCallback(
-    (remember?: boolean | undefined) => {
+    (remember?: boolean) => {
       if (!param.token || param.type !== 'recovery') {
         throw new Error(errors.tokenMissingOrInvalid);
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,9 @@ import React, {
   useEffect,
   createContext,
   useContext,
-  // types
-  Dispatch,
-  SetStateAction,
-  ReactNode,
   useCallback,
+  // types
+  ReactNode,
 } from 'react';
 
 import GoTrue, {
@@ -48,7 +46,7 @@ type MaybeUserPromise = Promise<User | undefined>;
 export type ReactNetlifyIdentityAPI = {
   user: User | undefined;
   /** not meant for normal use! you should mostly use one of the other exported methods to update the user instance */
-  setUser: Dispatch<SetStateAction<User | undefined>>;
+  setUser: (_user: GoTrueUser | undefined) => GoTrueUser | undefined;
   isConfirmedUser: boolean;
   isLoggedIn: boolean;
   signupUser: (
@@ -294,7 +292,7 @@ export function useNetlifyIdentity(
   return {
     user,
     /** not meant for normal use! you should mostly use one of the other exported methods to update the user instance */
-    setUser,
+    setUser: _setUser,
     isConfirmedUser: !!(user && user.confirmed_at),
     isLoggedIn: !!user,
     signupUser,

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,8 +1,8 @@
 export type TokenParam = {
   token: string | undefined;
   type: 'invite' | 'recovery' | 'email_change' | undefined;
-  error?: 'access_denied';
-  status?: 403;
+  error: 'access_denied' | undefined;
+  status: 403 | undefined;
 };
 
 export const defaultParam: TokenParam = {


### PR DESCRIPTION
- fixes `recoverAccount()` not cleaning up token when rejected
- updates readme to v0.2.1, including example usage of the new `param`
- adds ability to trigger passed `onAuthChange` fn directly through passing `_setUser` instead of `setUser`
- minor typing issues fixed

on a sidenote, v0.2.0 reduced the recoverAccount complexity by a lot (comparing [before](https://github.com/ljosberinn/personal-react-boilerplate/blob/d3efdb8ca7/src/routes/public/ResetPasswordRoute/ConfirmPasswordResetForm.js#L25) and [after](https://github.com/ljosberinn/personal-react-boilerplate/blob/41063a5ee3/src/routes/public/ResetPasswordRoute/ConfirmPasswordResetForm.js#L25))