### PR TITLE
Store user after email confirmation

### DIFF
--- a/src/runRoutes.tsx
+++ b/src/runRoutes.tsx
@@ -58,7 +58,7 @@ export function runRoutes(
 
     if (params.confirmation_token) {
       gotrue
-        .confirm(params.confirmation_token)
+        .confirm(params.confirmation_token, remember)
         .then(setUser)
         .catch(console.error);
 


### PR DESCRIPTION
Closes #34 

🙇 `react-netlify-identity` crew!

While building out an auth flow using this library I noticed that the localStorage `gotrue.user` value wasn't being stored after a user follows the email verification link and is logged in. 

I'm not totally clear on if this is in some way intentional and if a user should be expected to login again after clicking the email verification link, if that's the case please feel free to disregard, otherwise I hope this helps!